### PR TITLE
provide shell scripts instead of travis commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+sudo: true
 jdk:
 - oraclejdk8
 notifications:
@@ -10,23 +11,19 @@ notifications:
     on_failure: always
     on_start: never
 install:
-- 'wget http://stedolan.github.io/jq/download/linux64/jq'
-- 'chmod +x ./jq'
-- 'sudo cp jq /usr/bin'
+- 'chmod +x ./.travis/install.sh'
+- './.travis/install.sh'
 script:
-- ./gradlew build shadowJar
+- 'chmod +x ./gradlew'
+- './gradlew travisFiles'
 after_success:
-- 'if [ ${TRAVIS_PULL_REQUEST} != "false" ]; then exit; fi'
-- 'if [ ${TRAVIS_BRANCH} != "master" ]; then exit; fi'
-- 'if [[ $(git log --format=%B -n 1 $TRAVIS_COMMIT) == *"[ci ignore]"* ]]; then exit; fi'
-- 'MGC_API=$(cat apiver.txt)'
-- 'SPONGE_API=$(cat sapiver.txt)'
-- 'BUILD_NUMBER=$(curl "https://api.github.com/repos/minigamecore/minigamecore/tags" | jq ".[0].name" | tr -d "\"")'
-- 'BUILD_NUMBER=$((BUILD_NUMBER+1))'
-- 'COMMIT_MESSAGE=$(curl "https://api.github.com/repos/minigamecore/minigamecore/commits/${TRAVIS_COMMIT}" | jq ".commit.message" | tr -d "\"")'
-- 'mv ${TRAVIS_BUILD_DIR}/build/libs/MinigameCore-{all,${MGC_API}-${BUILD_NUMBER}}.jar'
-- 'curl -v -X POST -d "{\"tag\": \"${BUILD_NUMBER}\",\"message\": \"MinigameCore Build ${BUILD_NUMBER}\",\"object\": \"${TRAVIS_COMMIT}\",\"type\": \"commit\"}" --header "Content-Type:application/json" -u Flibio:${GITHUB_OAUTH} "https://api.github.com/repos/MinigameCore/MinigameCore/git/tags"'
-- 'curl -v -X POST -d "{\"ref\": \"refs/tags/${BUILD_NUMBER}\",\"sha\": \"${TRAVIS_COMMIT}\"}" --header "Content-Type:application/json" -u Flibio:${GITHUB_OAUTH} "https://api.github.com/repos/MinigameCore/MinigameCore/git/refs"'
-- 'curl -v -X POST -d "{\"tag_name\": \"${BUILD_NUMBER}\",\"target_commitish\": \"master\",\"name\": \"MinigameCore Build ${BUILD_NUMBER}\", \"body\": \"${COMMIT_MESSAGE}\r\n\r\n**MinigameCore API:** ${MGC_API}\r\n\r\n**Sponge API:** ${SPONGE_API}\"}" --header "Content-Type:application/json" -u Flibio:${GITHUB_OAUTH} "https://api.github.com/repos/MinigameCore/MinigameCore/releases"'
-- 'RELASE_ID=$(curl "https://api.github.com/repos/minigamecore/minigamecore/releases/latest" | jq ".id" | tr -d "\"")'
-- 'curl -v -X POST --data-binary @${HOME}/build/${TRAVIS_REPO_SLUG}/build/libs/MinigameCore-${MGC_API}-${BUILD_NUMBER}.jar --header "Content-Type:application/octet-stream" -u Flibio:${GITHUB_OAUTH} "https://uploads.github.com/repos/MinigameCore/MinigameCore/releases/${RELASE_ID}/assets?name=MinigameCore-${MGC_API}-${BUILD_NUMBER}.jar"'
+- 'echo "Setting some environment variables"'
+- 'export PULL_REQUEST=${TRAVIS_PULL_REQUEST}'
+- 'export BRANCH=${TRAVIS_BRANCH}'
+- 'export COMMIT=${TRAVIS_COMMIT}'
+- 'export BUILD_DIR=${TRAVIS_BUILD_DIR}'
+- 'export OAUTH=${GITHUB_OAUTH}'
+- 'export HOME_=${HOME}'
+- 'export REPO_SLUG=${TRAVIS_REPO_SLUG}'
+- 'chmod +x .travis/after_success.sh'
+- './.travis/after_success.sh'

--- a/.travis/after_success.sh
+++ b/.travis/after_success.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# TODO handle the error codes
+
+###############################
+# RESULT codes and meanings   #
+###############################
+# -128: default, nothing      #
+#       occurred. Major       #
+#       issues in our logic.  #
+# -3: Marked for ignore       #
+# -2: Not master branch       #
+# -1: Detected pull request   #
+# 0: Everything according to  #
+#    plan.                    #
+###############################
+RESULT=-128
+
+###############################
+# Automatically prints the    #
+# result code and exits       #
+###############################
+exit_check() {
+    echo "Result:"${RESULT}
+
+    case ${RESULT} in
+
+        -128    )
+            echo "There seems to be a major flaw in the logic"
+            echo "Contact the devs to get this fixed"
+            ;;
+
+        -3      )
+            echo "Stopping as marked for ignore"
+            # The build went according to plan
+            RESULT=0
+            ;;
+
+        -2      )
+            echo "Stopping as not master branch"
+            # The build went according to plan
+            RESULT=0
+            ;;
+
+        -1      )
+            echo "Stopping as PR detected"
+            # The build went according to plan
+            RESULT=0
+            ;;
+
+        0       )
+            echo "Success!"
+            ;;
+
+        *       )
+            echo "Unknown result found"
+            echo "Contact the devs to get this fixed"
+            ;;
+
+    esac
+
+    exit ${RESULT}
+}
+
+###############################
+# Check Prerequisites         #
+###############################
+echo "Checking Prerequisites"
+
+# Should not a pull request
+if [[ ${PULL_REQUEST} != "false" ]]; then
+    RESULT=-1
+    exit_check
+fi
+
+# We only release for master branch
+if [[ ${BRANCH} != "master" ]]; then
+    RESULT=-2
+    exit_check
+fi
+
+# Commits that have [ci ignore] are not to be released
+if [[ $(git log --format=%B -n 1 ${COMMIT}) == *"[ci ignore]"* ]]; then
+    RESULT=-3
+    exit_check
+fi
+
+###############################
+# Finish Prerequisites        #
+###############################
+
+# MinigameCore API version
+MGC_API=$(cat .travis/apiver.txt)
+SPONGE_API=$(cat .travis/sapiver.txt)
+
+# The build number
+BUILD_NUMBER=$(curl "https://api.github.com/repos/minigamecore/minigamecore/tags" | jq ".[0].name" | tr -d "\"")
+BUILD_NUMBER=$((BUILD_NUMBER+1))
+
+# The commit message
+COMMIT_MESSAGE=$(curl "https://api.github.com/repos/minigamecore/minigamecore/commits/${COMMIT}" | jq ".commit.message" | tr -d "\"")
+
+mv ${BUILD_DIR}/build/libs/MinigameCore-{all,${MGC_API}-${BUILD_NUMBER}}.jar
+
+curl -v -X POST -d "{\"tag\": \"${BUILD_NUMBER}\",\"message\": \"MinigameCore Build ${BUILD_NUMBER}\",\"object\": \"${COMMIT}\",\"type\": \"commit\"}" --header "Content-Type:application/json" -u Flibio:${OAUTH} "https://api.github.com/repos/MinigameCore/MinigameCore/git/tags"
+
+curl -v -X POST -d "{\"ref\": \"refs/tags/${BUILD_NUMBER}\",\"sha\": \"${COMMIT}\"}" --header "Content-Type:application/json" -u Flibio:${OAUTH} "https://api.github.com/repos/MinigameCore/MinigameCore/git/refs"
+
+curl -v -X POST -d "{\"tag_name\": \"${BUILD_NUMBER}\",\"target_commitish\": \"master\",\"name\": \"MinigameCore Build ${BUILD_NUMBER}\", \"body\": \"${COMMIT_MESSAGE}\r\n\r\n**MinigameCore API:** ${MGC_API}\r\n\r\n**Sponge API:** ${SPONGE_API}\"}" --header "Content-Type:application/json" -u Flibio:${OAUTH} "https://api.github.com/repos/MinigameCore/MinigameCore/releases"
+
+# Release id
+RELEASE_ID=$(curl "https://api.github.com/repos/minigamecore/minigamecore/releases/latest" | jq ".id" | tr -d "\"")
+
+curl -v -X POST --data-binary @${HOME_}/build/${TRAVIS_REPO_SLUG}/build/libs/MinigameCore-${MGC_API}-${BUILD_NUMBER}.jar --header "Content-Type:application/octet-stream" -u Flibio:${OAUTH} "https://uploads.github.com/repos/MinigameCore/MinigameCore/releases/${RELEASE_ID}/assets?name=MinigameCore-${MGC_API}-${BUILD_NUMBER}.jar"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+###############################
+# Get JQ                      #
+###############################
+echo "Downloading JQ"
+wget http://stedolan.github.io/jq/download/linux64/jq
+echo "Downloaded JQ"
+
+echo "Installing JQ"
+chmod +x ./jq
+sudo cp /usr/bin
+echo "Installed JQ"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import java.time.LocalDate
-
 plugins {
     id 'eclipse'
     id 'maven'
@@ -10,48 +8,13 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
-defaultTasks 'clean', 'build', 'shadowJar'
+defaultTasks 'shadowJar'
 
-build {
-    logger.lifecycle('MinigameCoreAPI: ' + project(':MinigameCoreAPI').version)
-    logger.lifecycle('SpongeAPI: ' + project(':MinigameCoreAPI').spongeapi)
-    def apifile = new File('apiver.txt')
-    apifile.text = project(':MinigameCoreAPI').version.minus("-SNAPSHOT")
-    def sapifile = new File('sapiver.txt')
-    sapifile.text = project(':MinigameCoreAPI').spongeapi.minus("-SNAPSHOT")
-}
-
-repositories {
-    maven {
-        name 'JitPack'
-        url 'https://jitpack.io'
-    }
-}
+apply from: 'gradle/travis/files.gradle'
+apply from: 'MinigameCoreAPI/gradle/shared.gradle'
 
 dependencies {
-    compile 'org.spongepowered:spongeapi:' + project.spongeapi
     compile project(':MinigameCoreAPI')
-}
-
-spotless {
-    java {
-        importOrderFile 'gradle/spotless/order.importorder'
-        eclipseFormatFile 'gradle/spotless/formatter.xml'
-        custom 'Long literal fix', { it.replaceAll('([0-9_]+) [Ll]', '$1L') }
-    }
-}
-
-license {
-    ext {
-        name = project.name
-        organization = project.organization
-        url = project.url
-        inceptionYear = '2016'
-        currentYear = LocalDate.now().getYear();
-    }
-
-    header = file('gradle/HEADER.txt')
-    include '**/*.java'
 }
 
 spongestart {
@@ -59,11 +22,13 @@ spongestart {
 }
 
 shadowJar {
+    dependsOn build
+
     classifier 'all'
-    baseName 'MinigameCore'
+    baseName project.name
     version = null
     configurations = [project.configurations.compile]
     dependencies {
-        include(dependency('io.github.minigamecore:MinigameCoreAPI'))
+        include(dependency(':MinigameCoreAPI'))
     }
 }

--- a/gradle/travis/files.gradle
+++ b/gradle/travis/files.gradle
@@ -1,0 +1,11 @@
+task travisFiles {
+    dependsOn shadowJar
+
+    logger.lifecycle('MinigameCoreAPI: ' + project(':MinigameCoreAPI').version)
+    def apifile = new File('.travis/apiver.txt')
+    apifile.text = project(':MinigameCoreAPI').version.minus("-SNAPSHOT")
+
+    logger.lifecycle('SpongeAPI: ' + project(':MinigameCoreAPI').spongeapi)
+    def sapifile = new File('.travis/sapiver.txt')
+    sapifile.text = project(':MinigameCoreAPI').spongeapi.minus("-SNAPSHOT")
+}


### PR DESCRIPTION
hopefully this works.

also now `apiver.txt` and `sapiver.txt` are not generated on our side unless `gradle travisFiles` is run.