### PR TITLE
add MinigameCoreLogger

### DIFF
--- a/src/main/java/io/github/minigamecore/plugin/config/ConfigurationManagerImpl.java
+++ b/src/main/java/io/github/minigamecore/plugin/config/ConfigurationManagerImpl.java
@@ -28,9 +28,10 @@ package io.github.minigamecore.plugin.config;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.spongepowered.api.Sponge.getPluginManager;
 
-import com.google.inject.Singleton;
 import io.github.minigamecore.api.util.config.Configuration;
 import io.github.minigamecore.api.util.config.ConfigurationManager;
+import io.github.minigamecore.plugin.util.logger.MinigameCoreLogger;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,10 +39,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Singleton
 public final class ConfigurationManagerImpl implements ConfigurationManager {
 
-    private Map<Object, List<Configuration>> configMap = new HashMap<>();
+    private final Logger logger = new MinigameCoreLogger("ConfigurationManager");
+    private final Map<Object, List<Configuration>> configMap = new HashMap<>();
 
     @Override
     public void register(final Object plugin, final Configuration config) {

--- a/src/main/java/io/github/minigamecore/plugin/config/Configurations.java
+++ b/src/main/java/io/github/minigamecore/plugin/config/Configurations.java
@@ -34,7 +34,9 @@ import static org.spongepowered.api.Sponge.getPluginManager;
 
 import io.github.minigamecore.api.util.config.Configuration;
 import io.github.minigamecore.plugin.MinigameCore;
+import org.slf4j.Logger;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,6 +73,24 @@ public final class Configurations {
 
     public static List<Configuration> getAll() {
         return configMap.entrySet().stream().map(Map.Entry::getValue).collect(toList());
+    }
+
+    // Special case for global.conf.
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    public static void loadGlobal(Logger logger) {
+        try {
+            get("global").get().load();
+        } catch (IOException e) {
+            logger.error("Failed to load global configuration. This is going to be a problem!", e);
+        }
+    }
+
+    public static void saveGlobal(Logger logger) {
+        try {
+            Configurations.get("global").get().save();
+        } catch (IOException e) {
+            logger.error("Failed to save global configuration.", e);
+        }
     }
 
 }

--- a/src/main/java/io/github/minigamecore/plugin/config/package-info.java
+++ b/src/main/java/io/github/minigamecore/plugin/config/package-info.java
@@ -23,7 +23,6 @@
  * THE SOFTWARE.
  */
 
-//TODO do javadocs
 @ParametersAreNonnullByDefault
 package io.github.minigamecore.plugin.config;
 

--- a/src/main/java/io/github/minigamecore/plugin/service/MinigameServiceImpl.java
+++ b/src/main/java/io/github/minigamecore/plugin/service/MinigameServiceImpl.java
@@ -33,17 +33,20 @@ import com.google.inject.Module;
 import com.google.inject.Singleton;
 import io.github.minigamecore.api.MinigameService;
 import io.github.minigamecore.api.util.config.ConfigurationManager;
+import io.github.minigamecore.plugin.util.logger.MinigameCoreLogger;
+import org.slf4j.Logger;
 
 import javax.annotation.Nonnull;
 
 /*
  * The implementation for MinigameService.
  */
-@Singleton // Only one instance should be available
+@Singleton
 public final class MinigameServiceImpl implements MinigameService {
 
     private Injector injector;
     private final ConfigurationManager configManager;
+    private final Logger logger = new MinigameCoreLogger("MinigameService");
 
     @Inject
     private MinigameServiceImpl(ConfigurationManager configManager) {
@@ -74,6 +77,13 @@ public final class MinigameServiceImpl implements MinigameService {
     @Override
     public ConfigurationManager getConfigurationManager() {
         return configManager;
+    }
+
+    /*
+     * Special case for first time initialization.
+     */
+    public void setInjector(@Nonnull Injector injector) {
+        this.injector = injector;
     }
 
 }

--- a/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLogger.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLogger.java
@@ -1,0 +1,478 @@
+/*
+ * This file is part of MinigameCore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016 - 2016 MinigameCore <http://minigamecore.github.io>
+ * Copyright (c) Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.github.minigamecore.plugin.util.logger;
+
+import static io.github.minigamecore.plugin.config.Configurations.get;
+import static io.github.minigamecore.plugin.util.logger.MinigameCoreLoggerUtil.Level.DEBUG;
+import static io.github.minigamecore.plugin.util.logger.MinigameCoreLoggerUtil.Level.ERROR;
+import static io.github.minigamecore.plugin.util.logger.MinigameCoreLoggerUtil.Level.INFO;
+import static io.github.minigamecore.plugin.util.logger.MinigameCoreLoggerUtil.Level.TRACE;
+import static io.github.minigamecore.plugin.util.logger.MinigameCoreLoggerUtil.Level.WARN;
+import static io.github.minigamecore.plugin.util.logger.MinigameCoreLoggerUtil.addToBuffer;
+import static java.lang.String.format;
+import static java.time.LocalTime.now;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.google.common.base.Objects;
+import com.google.inject.Singleton;
+import ninja.leaping.configurate.commented.CommentedConfigurationNode;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+import javax.annotation.Nullable;
+
+/**
+ * The MinigameCore implementation of {@link Logger}.
+ */
+@Singleton
+public class MinigameCoreLogger implements Logger {
+
+    @SuppressWarnings("OptionalGetWithoutIsPresent")
+    private final CommentedConfigurationNode globalConfig = get("global").get().get();
+    private final Logger logger;
+
+    @SuppressWarnings("ConstantConditions")
+    public MinigameCoreLogger() {
+        this(null);
+    }
+
+    public MinigameCoreLogger(@Nullable String suffix) {
+        final String prefix = "minigamecore";
+        logger = getLogger((suffix == null) ? prefix : prefix + "|" + suffix);
+    }
+
+    @Override
+    public String getName() {
+        return logger.getName();
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        return logger.isTraceEnabled();
+    }
+
+    @Override
+    public void trace(String msg) {
+        addToBuffer(now(), TRACE, this, msg);
+        logger.trace(msg);
+    }
+
+    @Override
+    public void trace(Marker marker, String msg) {
+        addToBuffer(now(), TRACE, this, msg);
+        logger.trace(marker, msg);
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+        addToBuffer(now(), TRACE, this, format(format, arg));
+        logger.trace(format, arg);
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+        addToBuffer(now(), TRACE, this, format(format, arg1, arg2));
+        logger.trace(format, arg1, arg2);
+    }
+
+    @Override
+    public void trace(String format, Object[] arguments) {
+        addToBuffer(now(), TRACE, this, format(format, arguments));
+        logger.trace(format, arguments);
+    }
+
+    @Override
+    public void trace(String msg, Throwable throwable) {
+        addToBuffer(now(), TRACE, this, msg, throwable);
+        logger.trace(msg, throwable);
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg) {
+        addToBuffer(now(), TRACE, this, format(format, arg));
+        logger.trace(marker, format, arg);
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object arg1, Object arg2) {
+        addToBuffer(now(), TRACE, this, format(format, arg1, arg2));
+        logger.trace(marker, format, arg1, arg2);
+    }
+
+    @Override
+    public void trace(Marker marker, String format, Object[] arguments) {
+        addToBuffer(now(), TRACE, this, format(format, arguments));
+        logger.trace(marker, format, arguments);
+    }
+
+    @Override
+    public void trace(Marker marker, String msg, Throwable throwable) {
+        addToBuffer(now(), TRACE, this, msg, throwable);
+        logger.trace(marker, msg, throwable);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return logger.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        return logger.isDebugEnabled(marker);
+    }
+
+    @Override
+    public void debug(String msg) {
+        addToBuffer(now(), DEBUG, this, msg);
+        logger.debug(msg);
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+        addToBuffer(now(), DEBUG, this, format(format, arg));
+        logger.debug(format, arg);
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+        addToBuffer(now(), DEBUG, this, format(format, arg1, arg2));
+        logger.debug(format, arg1, arg2);
+    }
+
+    @Override
+    public void debug(String format, Object[] arguments) {
+        addToBuffer(now(), DEBUG, this, format(format, arguments));
+        logger.debug(format, arguments);
+    }
+
+    @Override
+    public void debug(String msg, Throwable throwable) {
+        addToBuffer(now(), DEBUG, this, msg, throwable);
+        logger.debug(msg, throwable);
+    }
+
+    @Override
+    public void debug(Marker marker, String msg) {
+        addToBuffer(now(), DEBUG, this, msg);
+        logger.debug(marker, msg);
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg) {
+        addToBuffer(now(), DEBUG, this, format(format, arg));
+        logger.debug(marker, format, arg);
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object arg1, Object arg2) {
+        addToBuffer(now(), DEBUG, this, format(format, arg1, arg2));
+        logger.debug(marker, format, arg1, arg2);
+    }
+
+    @Override
+    public void debug(Marker marker, String format, Object[] arguments) {
+        addToBuffer(now(), DEBUG, this, format(format, arguments));
+        logger.debug(marker, format, arguments);
+    }
+
+    @Override
+    public void debug(Marker marker, String msg, Throwable throwable) {
+        addToBuffer(now(), DEBUG, this, msg, throwable);
+        logger.debug(marker, msg, throwable);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return logger.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        return logger.isInfoEnabled(marker);
+    }
+
+    @Override
+    public void info(String msg) {
+        addToBuffer(now(), INFO, this, msg);
+        logger.info(msg);
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+        addToBuffer(now(), INFO, this, format(format, arg));
+        logger.info(format, arg);
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+        addToBuffer(now(), INFO, this, format(format, arg1, arg2));
+        logger.info(format, arg1, arg2);
+    }
+
+    @Override
+    public void info(String format, Object[] arguments) {
+        addToBuffer(now(), INFO, this, format(format, arguments));
+        logger.info(format, arguments);
+    }
+
+    @Override
+    public void info(String msg, Throwable throwable) {
+        addToBuffer(now(), INFO, this, msg, throwable);
+
+        if (isDebug()) {
+            logger.info(msg, throwable);
+        } else {
+            logger.info(msg);
+        }
+    }
+
+    @Override
+    public void info(Marker marker, String msg) {
+        addToBuffer(now(), INFO, this, msg);
+        logger.info(marker, msg);
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg) {
+        addToBuffer(now(), INFO, this, format(format, arg));
+        logger.info(marker, format, arg);
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object arg1, Object arg2) {
+        addToBuffer(now(), INFO, this, format(format, arg1, arg2));
+        logger.info(marker, format, arg1, arg2);
+    }
+
+    @Override
+    public void info(Marker marker, String format, Object[] arguments) {
+        addToBuffer(now(), INFO, this, format(format, arguments));
+        logger.info(marker, format, arguments);
+    }
+
+    @Override
+    public void info(Marker marker, String msg, Throwable throwable) {
+        addToBuffer(now(), INFO, this, msg, throwable);
+
+        if (isDebug()) {
+            logger.info(marker, msg, throwable);
+        } else {
+            logger.info(marker, msg);
+        }
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return logger.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        return logger.isWarnEnabled(marker);
+    }
+
+    @Override
+    public void warn(String msg) {
+        addToBuffer(now(), WARN, this, msg);
+        logger.warn(msg);
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+        addToBuffer(now(), WARN, this, format(format, arg));
+        logger.warn(format, arg);
+    }
+
+    @Override
+    public void warn(String format, Object[] arguments) {
+        addToBuffer(now(), WARN, this, format(format, arguments));
+        logger.warn(format, arguments);
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+        addToBuffer(now(), WARN, this, format(format, arg1, arg2));
+        logger.warn(format, arg1, arg2);
+    }
+
+    @Override
+    public void warn(String msg, Throwable throwable) {
+        addToBuffer(now(), WARN, this, msg, throwable);
+
+        if (isDebug()) {
+            logger.warn(msg, throwable);
+        } else {
+            logger.warn(msg);
+        }
+    }
+
+    @Override
+    public void warn(Marker marker, String msg) {
+        addToBuffer(now(), WARN, this, msg);
+        logger.warn(marker, msg);
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg) {
+        addToBuffer(now(), WARN, this, format(format, arg));
+        logger.warn(marker, format, arg);
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object arg1, Object arg2) {
+        addToBuffer(now(), WARN, this, format(format, arg1, arg2));
+        logger.warn(marker, format, arg1, arg2);
+    }
+
+    @Override
+    public void warn(Marker marker, String format, Object[] arguments) {
+        addToBuffer(now(), WARN, this, format(format, arguments));
+        logger.warn(marker, format, arguments);
+    }
+
+    @Override
+    public void warn(Marker marker, String msg, Throwable throwable) {
+        addToBuffer(now(), WARN, this, msg, throwable);
+
+        if (isDebug()) {
+            logger.warn(marker, msg, throwable);
+        } else {
+            logger.warn(msg, throwable);
+        }
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return logger.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        return logger.isErrorEnabled(marker);
+    }
+
+    @Override
+    public void error(String msg) {
+        addToBuffer(now(), ERROR, this, msg);
+        logger.error(msg);
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+        addToBuffer(now(), ERROR, this, format(format, arg));
+        logger.error(format, arg);
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+        addToBuffer(now(), ERROR, this, format(format, arg1, arg2));
+        logger.error(format, arg1, arg2);
+    }
+
+    @Override
+    public void error(String format, Object[] arguments) {
+        addToBuffer(now(), ERROR, this, format(format, arguments));
+        logger.error(format, arguments);
+    }
+
+    @Override
+    public void error(String msg, Throwable throwable) {
+        addToBuffer(now(), ERROR, this, msg, throwable);
+
+        if (isDebug()) {
+            logger.error(msg, throwable);
+        } else {
+            logger.error(msg);
+        }
+    }
+
+    @Override
+    public void error(Marker marker, String msg) {
+        addToBuffer(now(), ERROR, this, msg);
+        logger.error(marker, msg);
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg) {
+        addToBuffer(now(), ERROR, this, format(format, arg));
+        logger.error(marker, format, arg);
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object arg1, Object arg2) {
+        addToBuffer(now(), ERROR, this, format(format, arg1, arg2));
+        logger.error(marker, format, arg1, arg2);
+    }
+
+    @Override
+    public void error(Marker marker, String format, Object[] arguments) {
+        addToBuffer(now(), ERROR, this, format(format, arguments));
+        logger.error(marker, format, arguments);
+    }
+
+    @Override
+    public void error(Marker marker, String msg, Throwable throwable) {
+        addToBuffer(now(), ERROR, this, msg, throwable);
+
+        if (isDebug()) {
+            logger.error(marker, msg, throwable);
+        } else {
+            logger.error(msg);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(logger);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return !((o == null) || !(o instanceof MinigameCoreLogger)) && Objects.equal(logger, ((MinigameCoreLogger) o).logger);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("name", getName())
+                .add("debug", isDebugEnabled())
+                .add("error", isErrorEnabled())
+                .add("info", isInfoEnabled())
+                .add("trace", isTraceEnabled())
+                .add("warn", isWarnEnabled())
+                .toString();
+    }
+
+    private boolean isDebug() {
+        return globalConfig.getNode("logging", "debug").getBoolean();
+    }
+
+}

--- a/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLoggerModule.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLoggerModule.java
@@ -23,4 +23,20 @@
  * THE SOFTWARE.
  */
 
-package io.github.minigamecore.plugin.config.annotations;
+package io.github.minigamecore.plugin.util.logger;
+
+import com.google.inject.AbstractModule;
+import io.github.minigamecore.plugin.util.logger.annotations.MinigameCoreLog;
+import org.slf4j.Logger;
+
+/**
+ * The {@link MinigameCoreLogger} bindings.
+ */
+public final class MinigameCoreLoggerModule extends AbstractModule {
+
+    @Override
+    protected void configure() {
+        bind(Logger.class).annotatedWith(MinigameCoreLog.class).to(MinigameCoreLogger.class).asEagerSingleton();
+    }
+
+}

--- a/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLoggerUtil.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLoggerUtil.java
@@ -1,0 +1,170 @@
+/*
+ * This file is part of MinigameCore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016 - 2016 MinigameCore <http://minigamecore.github.io>
+ * Copyright (c) Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.github.minigamecore.plugin.util.logger;
+
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.spongepowered.api.Sponge.getScheduler;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.github.minigamecore.plugin.MinigameCore;
+import io.github.minigamecore.plugin.config.Configurations;
+import org.slf4j.Logger;
+import org.spongepowered.api.scheduler.Task;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * The utility class for {@link MinigameCoreLogger}.
+ */
+public final class MinigameCoreLoggerUtil {
+
+    private static final List<String> logBuffer = Lists.newArrayList();
+    private static File logFile;
+
+    static void addToBuffer(LocalTime time, Level level, Logger logger, String message) {
+        String val = "[" + time.toString() + "] [" + level + "] [" + logger.getName() + "]: " + message + "\n";
+        logBuffer.add(val);
+    }
+
+    static void addToBuffer(LocalTime time, Level level, Logger logger, String message, Throwable throwable) {
+        addToBuffer(time, level, logger, message);
+        addToBuffer(time, level, logger, getStackTraceAsString(throwable));
+    }
+
+    public static void compress(Logger logger) {
+
+        try (BufferedOutputStream outputStream = new BufferedOutputStream(new GZIPOutputStream(new FileOutputStream(logFile.toString() + ".gz")));
+                BufferedInputStream inputStream = new BufferedInputStream(new FileInputStream(logFile))) {
+            byte[] buffer = new byte[1024];
+            int length;
+
+            while ((length = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, length);
+            }
+
+            Files.deleteIfExists(logFile.toPath());
+        } catch (IOException e) {
+            logger.error(format("Error compressing %s to %s. Deleting %s", logFile, logFile.toString() + ".gz", logFile.toString() + ".gz"), e);
+
+            try {
+                Files.deleteIfExists(Paths.get(logFile.toString() + ".gz"));
+            } catch (IOException e1) {
+                logger.error(format("Error deleting %s", logFile.toString() + ".gz"), e);
+            }
+        }
+    }
+
+    public static void createLogFile(MinigameCore plugin, String date, Logger logger) {
+        Path dir = Paths.get("logs", plugin.getPluginContainer().getId());
+
+        if (Files.notExists(dir)) {
+
+            try {
+                Files.createDirectories(dir);
+            } catch (IOException e) {
+                e.printStackTrace(); // TODO log
+            }
+        }
+
+        //noinspection ConstantConditions
+        for (int i = 1; i <= Short.MAX_VALUE; i++) {
+            Path file = dir.resolve(date + "-" + i + ".log");
+
+            if (Files.notExists(file) && Files.notExists(Paths.get(file.toString() + ".gz"))) {
+                try {
+                    Files.createFile(file);
+                    schedule(plugin);
+                } catch (IOException e) {
+                    e.printStackTrace(); // TODO log
+                }
+
+                logFile = file.toFile();
+                schedule(plugin);
+                break;
+            }
+        }
+    }
+
+    public static void flush(Logger logger) {
+        List<String> logBuffer = ImmutableList.copyOf(MinigameCoreLoggerUtil.logBuffer);
+        MinigameCoreLoggerUtil.logBuffer.clear();
+
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(logFile, true))) {
+            logBuffer.forEach(log -> {
+
+                try {
+                    writer.write(log);
+                } catch (IOException e) {
+                    logger.warn("Could not save log message.", e);
+                }
+            });
+        } catch (IOException e) {
+            logger.warn("Could not save log message.", e);
+        }
+    }
+
+    public static void schedule(MinigameCore plugin) {
+        //noinspection OptionalGetWithoutIsPresent
+        final long interval = Configurations.get("global").get().get().getNode("logging", "flush").getLong(15L);
+        getScheduler().createTaskBuilder().async().name(plugin.getPluginContainer().getId() + "-A-640").delay(interval, SECONDS)
+                .interval(interval, SECONDS).execute(() -> flush(plugin.getLogger())).submit(plugin);
+    }
+
+    public static void cancelTask(MinigameCore plugin) {
+        getScheduler().getTasksByName(plugin.getPluginContainer().getId() + "-A-640").forEach(Task::cancel);
+    }
+
+    private MinigameCoreLoggerUtil() {
+    }
+
+    /**
+     * The {@link Logger} levels for saving to log file.
+     */
+    public enum Level {
+        DEBUG,
+        ERROR,
+        INFO,
+        TRACE,
+        WARN
+    }
+
+}

--- a/src/main/java/io/github/minigamecore/plugin/util/logger/annotations/MinigameCoreLog.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/annotations/MinigameCoreLog.java
@@ -23,4 +23,26 @@
  * THE SOFTWARE.
  */
 
-package io.github.minigamecore.plugin.config.annotations;
+package io.github.minigamecore.plugin.util.logger.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.google.inject.BindingAnnotation;
+import io.github.minigamecore.plugin.util.logger.MinigameCoreLogger;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Binding annotation for {@link MinigameCoreLogger} with no suffix.
+ */
+@BindingAnnotation
+@Documented
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+public @interface MinigameCoreLog {
+
+}

--- a/src/main/java/io/github/minigamecore/plugin/util/logger/package-info.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/package-info.java
@@ -23,4 +23,7 @@
  * THE SOFTWARE.
  */
 
-package io.github.minigamecore.plugin.config.annotations;
+@ParametersAreNonnullByDefault
+package io.github.minigamecore.plugin.util.logger;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/main/resources/assets/minigamecore/config/global.conf
+++ b/src/main/resources/assets/minigamecore/config/global.conf
@@ -1,1 +1,12 @@
-debug = false
+# MinigameCore Logger settings
+logging {
+    # Should verbose logging be enabled.
+    # Prints exception stacktraces.
+    # Very important stacktraces will be printed even if this option is set to false.
+    # Default: false
+    debug = false
+    # How often (in seconds) should MinigameCore logger save to the log file.
+    # As a lot of logging occurs, this should be idly be between 15 and 30.
+    # Default: 15
+    flush = 15
+}


### PR DESCRIPTION
Closes #30 

This adds a `org.slf4j.Logger` wrapper, which automatically determines whether a log message is detailed with exceptions or not depending on `logging.debug` option in `global.conf` config. The default is `false`. 

The logger also writes the log messages to `logs/minigamecore/<date>-<xxx>.log`, where `<date>` is the date of creation and `<xxx>` is the current non-existent log file. There is a buffer to prevent constant IO. The `logging.flush` option in `global.conf` config specifies how often, in seconds, the buffer is saved to disk and cleared. The default is `15`

The `MinigameCoreLogger` itself implements `org.slf4j.Logger` so the method signatures don't change (although, initially that was not the case). The `MinigameCoreLoggerModule` provides bindings for the most often used loggers. An overloaded constructor is provided for special case logger suffixes.

~~TODO~~

~~A fine level setting for overrides debug setting if people want to disable/enable debug and trace level messages to be log file~~ decided against this


