### PR TITLE
Logger improvements

### DIFF
--- a/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLogger.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLogger.java
@@ -56,7 +56,11 @@ public class MinigameCoreLogger implements Logger {
 
     @SuppressWarnings("ConstantConditions")
     public MinigameCoreLogger() {
-        this(null);
+        this((String)null);
+    }
+
+    public MinigameCoreLogger(@Nullable Class suffix) {
+        this(suffix == null ? null : suffix.getCanonicalName());
     }
 
     public MinigameCoreLogger(@Nullable String suffix) {

--- a/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLoggerUtil.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/logger/MinigameCoreLoggerUtil.java
@@ -49,6 +49,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
@@ -61,7 +62,8 @@ public final class MinigameCoreLoggerUtil {
     private static File logFile;
 
     static void addToBuffer(LocalTime time, Level level, Logger logger, String message) {
-        String val = "[" + time.toString() + "] [" + level + "] [" + logger.getName() + "]: " + message + "\n";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+        String val = "[" + time.format(formatter) + "] [" + level + "] [" + logger.getName() + "]: " + message + "\n";
         logBuffer.add(val);
     }
 


### PR DESCRIPTION
improve the format of the time printed in the logs
add `MinigameCoreLogger(Class)` constructor to match `org.slf4j.Logger` impl