### PR TITLE
fix gradle checking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'java'
 apply plugin: 'idea'
 apply plugin: 'eclipse'
 
-defaultTasks 'checkstyleMain', 'shadowJar'
+defaultTasks 'check', 'shadowJar'
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/github/minigamecore/plugin/util/manager/GuiceManagerImpl.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/manager/GuiceManagerImpl.java
@@ -1,3 +1,28 @@
+/*
+ * This file is part of MinigameCore, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) 2016 - 2016 MinigameCore <http://minigamecore.github.io>
+ * Copyright (c) Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package io.github.minigamecore.plugin.util.manager;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/src/main/java/io/github/minigamecore/plugin/util/manager/package-info.java
+++ b/src/main/java/io/github/minigamecore/plugin/util/manager/package-info.java
@@ -1,5 +1,5 @@
 /*
- * This file is part of MinigameCoreAPI, licensed under the MIT License (MIT).
+ * This file is part of MinigameCore, licensed under the MIT License (MIT).
  *
  * Copyright (c) 2016 - 2016 MinigameCore <http://minigamecore.github.io>
  * Copyright (c) Contributors


### PR DESCRIPTION
Currently the default checking is only for checkstyle, this makes a check for license as well, as it was not going through